### PR TITLE
Fixed nonce validation

### DIFF
--- a/siwe.go
+++ b/siwe.go
@@ -235,7 +235,7 @@ func (m *Message) Verify(signature string, nonce *string, timestamp *time.Time) 
 	}
 
 	if nonce != nil {
-		if m.GetNonce() == *nonce {
+		if m.GetNonce() != *nonce {
 			return nil, &InvalidSignature{"Message nonce doesn't match"}
 		}
 	}


### PR DESCRIPTION
The current state of the code checks whether the nonces are the same to return an error instead of checking if the nonces are different.